### PR TITLE
feat(project): update translations and make them customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ class Example extends Component {
     return (
       <MultiModalComponent
         config={searchConfig}
-        placeholderText="Search for all music compositions..."
         onResultClick={node => console.log('User has clicked on:', node)}
+        i18n={{
+          'en-US': { searchBar: { placeholder_text: 'Search for all music compositions...' } },
+          'nl-NL': { searchBar: { placeholder_text: 'Zoek voor alle muziek composities...' } },
+        }}
       />
     )
   }
@@ -81,7 +84,8 @@ const searchConfig = new SearchConfig({
 |------|------|---------------|-------------|----------|
 | **searchConfig** | SearchConfig | undefined  | An instance of the SearchConfig class | Yes |
 | **onResultClick** | Function | function(**result**: *Object*) { }  | Callback when the user clicks on a result. | No |
-| **placeholderText** | String | Enter a search phrase... | Placeholder text for the search input | No |
+| **placeholderText (deprecated, use i18n)** | String | Enter a search phrase... | Placeholder text for the search input | No |
+| **i18n** | Object | undefined | Override translations | No |
 
 #### Currently supported searchTypes
 ```jsx

--- a/example/App.js
+++ b/example/App.js
@@ -9,13 +9,13 @@ import MultiModalComponent, { SearchConfig, searchTypes } from '../src/index';
 
 const BlockQuote = ({ children }) => {
   return (
-    <div style={{ backgroundColor: '#fff', borderLeft: `6px solid rgb(63 81 181)`, padding: 16, marginBottom: 8 }} >
+    <div style={{ backgroundColor: '#fff', borderLeft: `6px solid rgb(63 81 181)`, padding: 16, marginBottom: 8 }}>
       <Typography variant="caption">{children}</Typography>
     </div>
   );
 };
 
-const MultiModalComponentSelect = ({ config, placeholderText, production }) => {
+const MultiModalComponentSelect = ({ config, i18n, placeholderText, production }) => {
   const [open, setOpen]         = useState(false);
   const [selected, setSelected] = useState();
 
@@ -32,6 +32,7 @@ const MultiModalComponentSelect = ({ config, placeholderText, production }) => {
           uri={production ? 'https://api.trompamusic.eu' : 'https://api-test.trompamusic.eu'}
           config={config}
           placeholderText={placeholderText}
+          i18n={i18n}
           onResultClick={item => {
             setSelected(item);
             setOpen(false);
@@ -103,7 +104,14 @@ const App = () => {
         <BlockQuote>
           As a user I want to be able to find a single type (Person) with related facets and filters.
         </BlockQuote>
-        <MultiModalComponentSelect config={ex1Config} placeholderText="Search for Persons in the CE" production={production} />
+        <MultiModalComponentSelect
+          config={ex1Config}
+          i18n={{
+            'en-US': { searchBar: { placeholder_text: 'Search for Persons in the CE' } },
+            'nl-NL': { searchBar: { placeholder_text: 'Zoek naar Personen in de CE' } },
+          }}
+          production={production}
+        />
         <BlockQuote>
           As a user I want to be able to find multiple types (AudioObject and VideoObject) with related facets and filters.
         </BlockQuote>

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.5.16",
     "classnames": "^2.2.6",
+    "deepmerge": "^4.2.2",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
     "i18next": "^19.0.3",

--- a/src/MultiModalComponent.js
+++ b/src/MultiModalComponent.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { I18nextProvider } from 'react-i18next';
+import { I18nextProvider, withTranslation } from 'react-i18next';
 import * as PropTypes from 'prop-types';
 import { ApolloProvider } from 'react-apollo';
 import SearchProvider from './containers/SearchProvider';
 import { Search } from './containers/Search';
-import i18n from './i18n';
+import { getI18n } from './i18n';
 import { getApolloClient } from './client';
 import NavBar from './containers/NavBar';
 import SearchConfig from './search/SearchConfig';
@@ -15,27 +15,33 @@ class MultiModalComponent extends Component {
     uri            : PropTypes.string,
     onResultClick  : PropTypes.func,
     placeholderText: PropTypes.string,
+    i18n           : PropTypes.shape({
+      'nl-NL': PropTypes.object,
+      'en-US': PropTypes.object,
+    }),
   };
 
   static defaultProps = {
-    uri            : 'https://api-test.trompamusic.eu',
-    onResultClick  : () => true,
-    placeholderText: 'Enter your search phrase...',
+    uri          : 'https://api-test.trompamusic.eu',
+    onResultClick: () => true,
   };
 
   constructor(props) {
     super(props);
 
     this.client = getApolloClient(this.props.uri);
+    this.i18n   = getI18n(props.i18n);
   }
 
   render() {
+    const { config, placeholderText, onResultClick } = this.props;
+
     return (
       <ApolloProvider client={this.client}>
-        <I18nextProvider i18n={i18n}>
-          <SearchProvider client={this.client} config={this.props.config}>
-            <NavBar placeholderText={this.props.placeholderText} />
-            <Search onResultClick={this.props.onResultClick} />
+        <I18nextProvider i18n={this.i18n}>
+          <SearchProvider client={this.client} config={config}>
+            <NavBar placeholderText={placeholderText} />
+            <Search onResultClick={onResultClick} />
           </SearchProvider>
         </I18nextProvider>
       </ApolloProvider>

--- a/src/components/LanguageSelect/LanguageSelect.js
+++ b/src/components/LanguageSelect/LanguageSelect.js
@@ -3,7 +3,6 @@ import { withStyles } from '@material-ui/core/styles';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import Hidden from '@material-ui/core/Hidden';
 import { withTranslation } from 'react-i18next';
-import i18next from 'i18next';
 import { MenuItem, ListItemIcon, Menu } from '@material-ui/core';
 import ListItemText from '@material-ui/core/ListItemText';
 import usFlag from '../Icons/flags/en_US.svg';
@@ -24,7 +23,7 @@ class LanguageSelect extends Component {
 
   handleChange = country => {
     this.setState({ country });
-    i18next.changeLanguage(country);
+    this.props.i18n.changeLanguage(country);
     this.setState({ selectOpen: false });
   };
 

--- a/src/components/SearchFilter/SearchFilter.js
+++ b/src/components/SearchFilter/SearchFilter.js
@@ -10,6 +10,7 @@ import Link from '@material-ui/core/Link';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import IconButton from '@material-ui/core/IconButton';
 import { debounce } from 'throttle-debounce';
+import { withTranslation } from 'react-i18next';
 import styles from './SearchFilter.styles';
 
 class SearchFilter extends Component {
@@ -56,7 +57,7 @@ class SearchFilter extends Component {
   };
 
   render() {
-    const { classes, filter } = this.props;
+    const { classes, filter, t, i18n } = this.props;
 
     // there are no options
     if (!filter) {
@@ -68,7 +69,9 @@ class SearchFilter extends Component {
 
     return (
       <div className={classes.root} key={filter.name}>
-        <Typography className={classes.type} gutterBottom>{filter.name}</Typography>
+        <Typography className={classes.type} gutterBottom>
+          {i18n.exists(`searchFilters:filters.${filter.name}`) ? t(`searchFilters:filters.${filter.name}`) : filter.name}
+        </Typography>
         {filter.searchType ? (
           <TextField
             className={classes.filterTextField}
@@ -124,4 +127,4 @@ class SearchFilter extends Component {
   }
 }
 
-export default withStyles(styles)(SearchFilter);
+export default withTranslation('searchFilters')(withStyles(styles)(SearchFilter));

--- a/src/containers/NavBar/NavBar.js
+++ b/src/containers/NavBar/NavBar.js
@@ -17,7 +17,14 @@ export class NavBar extends Component {
   static defaultProps = {};
 
   render() {
-    const { classes, placeholderText } = this.props;
+    const { classes, placeholderText, t } = this.props;
+
+    let searchPlaceholderText = placeholderText;
+
+    // make the placeholderText prop backwards compatible. If given, use it.
+    if (!searchPlaceholderText) {
+      searchPlaceholderText = t('placeholder_text');
+    }
 
     return (
       <AppBar className={classes.root} position="static">
@@ -36,7 +43,7 @@ export class NavBar extends Component {
           <div className={classes.searchContainer}>
             <SearchContext.Consumer>
               {({ search }) => (
-                <SearchBar placeholderText={placeholderText} onSubmit={(event, searchPhrase, searchTags) => search(searchPhrase, searchTags)} />
+                <SearchBar placeholderText={searchPlaceholderText} onSubmit={(event, searchPhrase, searchTags) => search(searchPhrase, searchTags)} />
               )}
             </SearchContext.Consumer>
           </div>
@@ -48,6 +55,6 @@ export class NavBar extends Component {
 
 export default providers(
   NavBar,
-  withTranslation('navbar'),
+  withTranslation('searchBar'),
   withStyles(styles),
 );

--- a/src/containers/SearchFilters/SearchFilters.js
+++ b/src/containers/SearchFilters/SearchFilters.js
@@ -42,7 +42,7 @@ class SearchFilters extends Component {
               className={classes.button}
               onClick={() => this.setState({ openMobileFilters: false })}
             >
-              {`${total} ${t('results')}`}
+              {t('total_results', { count: total })}
             </Button>
           </div>
         </div>
@@ -78,7 +78,7 @@ class SearchFilters extends Component {
                 onClick={() => this.setState({ openMobileFilters: true })}
               >
                 <FilterIcon className={classes.buttonIcon} />
-                {`${t('filter')} ${total} ${t('results')}`}
+                {t('show_results', { count: total })}
               </Button>
               {this.renderMobileDrawer(filters, filtersState, updateFilter, total)}
             </Hidden>

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import deepmerge from 'deepmerge';
 import en_US from './locales/en_US';
 import nl_NL from './locales/nl_NL';
 
@@ -9,15 +10,23 @@ const locales = {
 };
 
 // initialize i18n, get all namespaces from the default language
-i18n
-  .use(initReactI18next)
-  .init({
-    debug      : process.env.NODE_ENV === 'development',
-    fallbackLng: 'en-US',
-    lng        : 'en-US',
-    ns         : Object.keys(locales['en-US']),
-    defaultNS  : 'common',
-    resources  : locales,
-  });
+export const getI18n = customTranslations => {
+  const i18nInstance = i18n.createInstance();
+
+  customTranslations = customTranslations || {};
+
+  i18nInstance
+    .use(initReactI18next)
+    .init({
+      debug      : process.env.NODE_ENV === 'development',
+      fallbackLng: 'en-US',
+      lng        : 'en-US',
+      ns         : Object.keys(locales['en-US']),
+      defaultNS  : 'common',
+      resources  : deepmerge(locales, customTranslations),
+    });
+
+  return i18nInstance;
+};
 
 export default i18n;

--- a/src/i18n/locales/en_US/index.js
+++ b/src/i18n/locales/en_US/index.js
@@ -1,4 +1,5 @@
 import footer from './footer.json';
+import searchBar from './searchBar.json';
 import searchResults from './searchResults.json';
 import searchFilters from './searchFilters.json';
 import languageSelect from './languageSelect.json';
@@ -6,6 +7,7 @@ import languageSelect from './languageSelect.json';
 /* eslint-disable key-spacing */
 export default {
   footer,
+  searchBar,
   searchResults,
   searchFilters,
   languageSelect,

--- a/src/i18n/locales/en_US/searchBar.json
+++ b/src/i18n/locales/en_US/searchBar.json
@@ -1,0 +1,3 @@
+{
+  "placeholder_text": "Enter your search phrase..."
+}

--- a/src/i18n/locales/en_US/searchFilters.json
+++ b/src/i18n/locales/en_US/searchFilters.json
@@ -1,27 +1,20 @@
 {
-  "filterBy": "Filter by",
-  "filter": "Filter",
-  "type": "Type",
-  "result": "result",
-  "results": "results",
-  "filterMenu": {
+  "show_results": "Filter {{count}} result",
+  "show_results_plural": "Filter {{count}} results",
+  "total_results": "{{count}} result",
+  "total_results_plural": "{{count}} results",
+  "filters": {
     "all": "All",
     "people": "People",
+    "composer": "Composer",
     "compositions": "Compositions",
-    "scores": "Scores",
+    "score": "Score",
+    "role": "Role",
+    "birthplace": "Birthplace",
+    "format": "Format",
     "annotations": "Annotations",
     "videos": "Videos",
-    "tracks": "Tracks"
-  },
-  "people": "People",
-  "peopleSubFilters": {
-    "composer": "Composer",
-    "musician": "Musician",
-    "conductor": "Conductor"
-  },
-  "compositions": "Compositions",
-  "articles": "Articles",
-  "organizations": "Organizations",
-  "products": "Products",
-  "places": "Places"
+    "tracks": "Tracks",
+    "type": "Type"
+  }
 }

--- a/src/i18n/locales/en_US/searchResults.json
+++ b/src/i18n/locales/en_US/searchResults.json
@@ -12,27 +12,6 @@
     "VideoObject": "Video",
     "VideoObject_plural": "Videos"
   },
-  "personResult": {
-    "person": "Person",
-    "personLower": "person",
-    "people": "People"
-  },
-  "compositionResult": {
-    "composition": "Composition",
-    "compositionLower": "composition",
-    "compositions": "Compositions"
-  },
-  "scoreResult": {
-    "score": "Score",
-    "scoreLower": "score",
-    "scores": "Scores",
-    "publisherInfo": "Publisher Info"
-  },
-  "videoResult": {
-    "video": "Video",
-    "videoLower": "video",
-    "videos": "Videos"
-  },
   "emptyResults": {
     "noResults": "We're sorry! We couldn't find results for \"{{searchPhrase}}\"",
     "noResultsCategory": "We're sorry! We couldn't find a {{type}} for \"{{searchPhrase}}\"",

--- a/src/i18n/locales/nl_NL/footer.json
+++ b/src/i18n/locales/nl_NL/footer.json
@@ -1,0 +1,3 @@
+{
+  "copyright": "© Trompa"
+}

--- a/src/i18n/locales/nl_NL/index.js
+++ b/src/i18n/locales/nl_NL/index.js
@@ -1,6 +1,14 @@
+import footer from './footer.json';
+import searchBar from './searchBar.json';
+import searchResults from './searchResults.json';
+import searchFilters from './searchFilters.json';
 import languageSelect from './languageSelect.json';
 
 /* eslint-disable key-spacing */
 export default {
+  footer,
+  searchBar,
+  searchResults,
+  searchFilters,
   languageSelect,
 };

--- a/src/i18n/locales/nl_NL/searchBar.json
+++ b/src/i18n/locales/nl_NL/searchBar.json
@@ -1,0 +1,3 @@
+{
+  "placeholder_text": "Vul je zoekterm in"
+}

--- a/src/i18n/locales/nl_NL/searchFilters.json
+++ b/src/i18n/locales/nl_NL/searchFilters.json
@@ -1,0 +1,20 @@
+{
+  "show_results": "Filter {{count}} resultaat",
+  "show_results_plural": "Filter {{count}} resultaten",
+  "total_results": "{{count}} resultaat",
+  "total_results_plural": "{{count}} resultaten",
+  "filters": {
+    "all": "All",
+    "people": "Personen",
+    "composer": "Componist",
+    "compositions": "Composities",
+    "score": "Partituur",
+    "role": "Rol",
+    "birthplace": "Geboorteplaats",
+    "format": "Formaat",
+    "annotations": "Annotaties",
+    "videos": "Videos",
+    "tracks": "Nummers",
+    "type": "Type"
+  }
+}

--- a/src/i18n/locales/nl_NL/searchResults.json
+++ b/src/i18n/locales/nl_NL/searchResults.json
@@ -1,28 +1,34 @@
 {
-  "results": "totale resultaten",
-  "personResult": {
-    "person": "Persoon",
-    "people": "Personen"
-  },
-  "compositionResult": {
-    "composition": "Compositie",
-    "compositions": "Composities"
-  },
-  "scoreResult": {
-    "score": "Partituur",
-    "scores": "Partituren"
-  },
-  "videoResult": {
-    "video": "Video",
-    "videos": "Videos"
+  "results": "{{count}} resultaat",
+  "results_plural": "{{count}} resultaten",
+  "types": {
+    "AudioObject": "Audio",
+    "Person": "Persoon",
+    "Person_plural": "Personen",
+    "MusicComposition": "Compositie",
+    "MusicComposition_plural": "Composities",
+    "DigitalDocument": "Partituur",
+    "DigitalDocument_plural": "Partituren",
+    "VideoObject": "Video",
+    "VideoObject_plural": "Videos"
   },
   "emptyResults": {
-    "noRole": "Unknown role",
-    "noDescription": "Geen descriptie.",
-    "noComposer": "Onbekende componist",
-    "noTitle": "Onbekende titel",
-    "noName": "Onbekende naam",
-    "noSource": "Onbekende bron"
+    "noResults": "Onze excuses! We konden geen resultaten vinden voor \"{{searchPhrase}}\"",
+    "noResultsCategory": "Onze excuses! We konden geen {{type}} vinden voor \"{{searchPhrase}}\"",
+    "noRole": "Rol onbekend",
+    "noDescription": "Beschrijving onbekend",
+    "noComposer": "Componist onbekend",
+    "noTitle": "Titel onbekend",
+    "noName": "Naam onbekend",
+    "noSource": "Bron onbekend",
+    "noPublisher": "Uitgever onbekend"
   },
-  "showMore": "Laat meer zien"
+  "searchTips": {
+    "searchTips": "Zoek tips",
+    "tryOtherFilter": "Probeer een andere filter",
+    "doubleCheck": "Controleer je spelling",
+    "tryAnother": "Probeer een ander woord",
+    "lessSpecific": "Probeer minder specifiek te zijn in je zoekopdracht"
+  },
+  "showMore": "Toon meer"
 }

--- a/src/search/SearchConfig.js
+++ b/src/search/SearchConfig.js
@@ -120,8 +120,6 @@ class SearchConfig {
 
     const filters = await this.buildFilters(client, filtersState, searchTypeResults);
 
-    console.log(filters);
-
     return {
       filters,
       flattenedResults,

--- a/src/search/types/AudioObject.js
+++ b/src/search/types/AudioObject.js
@@ -6,11 +6,11 @@ class AudioObject {
 
   static filters = [{
     onProperty: 'exampleOfWork',
-    name      : 'Score',
+    name      : 'score',
     searchType: DigitalDocument,
   }, {
     onProperty: 'format',
-    name      : 'Format',
+    name      : 'format',
   }];
 
   static searchAllQuery = gql`

--- a/src/search/types/DigitalDocument.js
+++ b/src/search/types/DigitalDocument.js
@@ -6,7 +6,7 @@ class DigitalDocument {
 
   static filters = [{
     onProperty: 'author',
-    name      : 'Composer',
+    name      : 'composer',
     searchType: Person,
   }];
 

--- a/src/search/types/MusicComposition.js
+++ b/src/search/types/MusicComposition.js
@@ -6,7 +6,7 @@ class MusicComposition {
 
   static filters = [{
     onProperty: 'author',
-    name      : 'Composer',
+    name      : 'composer',
     searchType: Person,
   }];
 

--- a/src/search/types/Person.js
+++ b/src/search/types/Person.js
@@ -6,10 +6,10 @@ class Person {
 
   static filters = [{
     onProperty: 'subject',
-    name      : 'Role',
+    name      : 'role',
   }, {
     onProperty: 'birthPlace',
-    name      : 'Birthplace',
+    name      : 'birthplace',
     searchType: Place,
   }];
 

--- a/src/search/types/VideoObject.js
+++ b/src/search/types/VideoObject.js
@@ -6,11 +6,11 @@ class VideoObject {
 
   static filters = [{
     onProperty: 'exampleOfWork',
-    name      : 'Score',
+    name      : 'score',
     searchType: DigitalDocument,
   }, {
     onProperty: 'format',
-    name      : 'Format',
+    name      : 'format',
   }];
 
   static searchAllQuery = gql`


### PR DESCRIPTION
This PR fixes some translation issues and enables developers to customize translations using an `i18n` prop.

For example:

```js
class Example extends Component {
  render () {
    return (
      <MultiModalComponent
        config={searchConfig}
        onResultClick={node => console.log('User has clicked on:', node)}
        i18n={{
          'en-US': { searchBar: { placeholder_text: 'Search for all music compositions...' } },
          'nl-NL': { searchBar: { placeholder_text: 'Zoek voor alle muziek composities...' } },
        }}
      />
    )
  }
}
```