### PR TITLE
optionally post-process results before displaying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,16 @@ class Example extends Component {
 }
 ```
 
+## Local development
+
+To start the example demo, run
+
+```bash
+npm run start:example
+```
+
+And visit http://localhost:5050 in a browser
+
 ## License
 
 Apache-2.0 ©

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ class Example extends Component {
 To start the example demo, run
 
 ```bash
-npm run start:example
+yarn start:example
 ```
 
 And visit http://localhost:5050 in a browser

--- a/example/App.js
+++ b/example/App.js
@@ -41,6 +41,53 @@ class CustomType {
   `;
 }
 
+class PostprocessCustomType {
+  static name = 'MusicComposition';
+
+  static filters = [];
+
+  static preprocessQuery = query => {
+    return `(?i).*${query}.*`;
+  }
+
+  static searchAllQuery = gql`
+    query($query: String!) {
+      ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
+        identifier
+        name
+        itemListElement(filter:{name_regexp:$query}) {
+          identifier
+          name
+        }
+      }
+    }
+  `;
+
+  static searchQuery = gql`
+    query($filter: _ThingInterfaceFilter) {
+      ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
+        identifier
+        name
+        itemListElement(filter: $filter) {
+          identifier
+          name
+        }
+      }
+    }
+  `;
+
+  static processSearchResult = result => {
+    // Find the itemListElements of this ItemList, instead of a list of ItemLists
+    if (result) {
+      if (result.data.ItemList) {
+        return result.data.ItemList[0].itemListElement;
+      }
+    }
+
+    return [];
+  }
+}
+
 const BlockQuote = ({ children }) => {
   return (
     <div style={{ backgroundColor: '#fff', borderLeft: `6px solid rgb(63 81 181)`, padding: 16, marginBottom: 8 }}>
@@ -126,6 +173,10 @@ const ex6Config = new SearchConfig({
   searchTypes: [CustomType, searchTypes.MusicComposition],
 });
 
+const ex7Config = new SearchConfig({
+  searchTypes: [PostprocessCustomType],
+});
+
 const App = () => {
   const [production, setProduction] = useState(false);
 
@@ -191,6 +242,10 @@ const App = () => {
             return <div onClick={() => onClick(item)}>MusicComposition: {item.title}</div>;
           }}
         />
+        <BlockQuote>
+          As a developer I want to be able to post-process search results.
+        </BlockQuote>
+        <MultiModalComponentSelect config={ex7Config} production={production} />
       </Paper>
       <Paper style={{ padding: 16, backgroundColor: '#f1f1f1', marginBottom: 64 }} color="red" variant="outlined">
         <Typography variant="h6" gutterBottom>Use cases:</Typography>

--- a/example/App.js
+++ b/example/App.js
@@ -52,7 +52,7 @@ class PostprocessCustomType {
 
   static searchAllQuery = gql`
     query($query: String!) {
-      ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
+      allResults: ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
         identifier
         name
         itemListElement(filter:{name_regexp:$query}) {
@@ -65,10 +65,10 @@ class PostprocessCustomType {
 
   static searchQuery = gql`
     query($filter: _ThingInterfaceFilter) {
-      ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
+      results: ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
         identifier
         name
-        itemListElement(filter: $filter) {
+        itemListElement(filter: $filter, first: 50) {
           identifier
           name
         }
@@ -78,10 +78,8 @@ class PostprocessCustomType {
 
   static processSearchResult = result => {
     // Find the itemListElements of this ItemList, instead of a list of ItemLists
-    if (result) {
-      if (result.data.ItemList) {
-        return result.data.ItemList[0].itemListElement;
-      }
+    if (Array.isArray(result) && result[0]) {
+      return result[0].itemListElement;
     }
 
     return [];

--- a/src/search/SearchConfig.js
+++ b/src/search/SearchConfig.js
@@ -70,22 +70,28 @@ class SearchConfig {
     const { data: { allResults } } = await client.query({
       query    : searchType.searchAllQuery,
       variables: {
-        query,
+        query: searchType.preprocessQuery ? searchType.preprocessQuery(query) : query,
       },
     });
+
+    let processedAllResults;
+
+    if (searchType.processSearchResult) {
+      processedAllResults = searchType.processSearchResult(allResults);
+    }
 
     const { data: { results } } = await client.query({
       query    : searchType.searchQuery,
       variables: {
-        filter: generateFilter(query, allResults, filtersState, this.filter),
+        filter: generateFilter(query, processedAllResults, filtersState, this.filter),
       },
     });
 
     return {
-      typename: searchType.name,
-      total   : results.length,
-      allResults,
-      results,
+      typename  : searchType.name,
+      total     : searchType.processSearchResult ? searchType.processSearchResult(results).length : results.length,
+      allResults: processedAllResults,
+      results   : searchType.processSearchResult ? searchType.processSearchResult(results) : results,
     };
   }
 

--- a/src/search/SearchConfig.js
+++ b/src/search/SearchConfig.js
@@ -74,9 +74,9 @@ class SearchConfig {
       },
     });
 
-    let processedAllResults;
+    let processedAllResults = allResults;
 
-    if (searchType.processSearchResult) {
+    if (typeof searchType.processSearchResult === 'function') {
       processedAllResults = searchType.processSearchResult(allResults);
     }
 
@@ -87,11 +87,17 @@ class SearchConfig {
       },
     });
 
+    let processedResults = results;
+
+    if (typeof searchType.processSearchResult === 'function') {
+      processedResults = searchType.processSearchResult(results);
+    }
+
     return {
       typename  : searchType.name,
-      total     : searchType.processSearchResult ? searchType.processSearchResult(results).length : results.length,
+      total     : processedResults.length,
       allResults: processedAllResults,
-      results   : searchType.processSearchResult ? searchType.processSearchResult(results) : results,
+      results   : processedResults,
     };
   }
 


### PR DESCRIPTION
As described in https://github.com/trompamusic/ce-api/issues/187, we sometimes have searches where the items that we want are returned as child objects of the main query, for example:

```graphql
query {
  ItemList(identifier:"e91489d7-a776-40dd-8abf-0c934922bd99") {
    identifier
    name
    itemListElement(filter:{name_regexp:"(?i).*missa.*"}) {
      identifier
      name
    }
  }
}
```

The items that we want are actually the MusicCompositions returned in `itemListElement`. This query cannot be done any other way because we don't have reverse relationships saying that an item is part of a list.

This change adds optional `preprocessQuery` and `processSearchResult` methods to search types so that we can do a query such as the one above, and then post-process the results and return a list of the expected objects.

There is still a bug, where I don't understand the reasoning behind performing two queries in `SearchConfig.performSearch` - first it runs `searchType.searchAllQuery` and then `searchType.searchQuery`. In the example that I made, the first result runs fine, but then the second one filters out everything, I'm sure I'm missing something simple in the data flow.

I see that some ordering code appears to assume that there is a _searchScore property in some returned items, which might also not be the case here.